### PR TITLE
export testArtifacts configuration from clouddriver-google

### DIFF
--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -5,3 +5,15 @@ dependencies {
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
 }
+
+// export tests for use in clouddriver-security
+configurations {
+    testArtifacts.extendsFrom testRuntime
+}
+task testJar(type: Jar) {
+    classifier "test"
+    from sourceSets.test.output
+}
+artifacts {
+    testArtifacts testJar
+}

--- a/clouddriver-security/clouddriver-security.gradle
+++ b/clouddriver-security/clouddriver-security.gradle
@@ -7,6 +7,6 @@ dependencies {
 
   testCompile project(':clouddriver-aws')
   testCompile project(':clouddriver-google')
-  testCompile project(':clouddriver-google').sourceSets.test.output
+  testCompile project(path: ':clouddriver-google', configuration: 'testArtifacts')
   testCompile project(':cats:cats-test')
 }


### PR DESCRIPTION
this ensures that the test runtime dependencies will get inherited by anyone that consumes the clouddriver-google test configuration
